### PR TITLE
Add a funcall way to invoke the elisp function

### DIFF
--- a/i3-call
+++ b/i3-call
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 I3_COMMAND=$1
 I3_ARG=$2
@@ -8,7 +8,13 @@ FOCUS_WINDOW_ID=$(xprop -root | awk '/_NET_ACTIVE_WINDOW\(WINDOW\)/{print $NF}')
 FOCUS_WINDOW_CLASS=$(xprop -id $FOCUS_WINDOW_ID | awk '/WM_CLASS/{print $NF}' | cut -d'"' -f2)
 
 if [[ $FOCUS_WINDOW_CLASS =~ ^[Ee]macs.* ]]; then
-    emacsclient -e "(i3-integrated-key \"$INPUT_KEYSYM\" \"$I3_COMMAND\" \"$I3_ARG\")"
+    if [[ "$INPUT_KEYSYM" == "#'"* ]]; then
+        INVOKE="i3-process-key"
+    else
+        INVOKE="i3-integrated-key"
+        INPUT_KEYSYM="\"$INPUT_KEYSYM\""
+    fi
+    emacsclient -e "($INVOKE $INPUT_KEYSYM \"$I3_COMMAND\" \"$I3_ARG\")"
 else
     i3-msg "$I3_COMMAND $I3_ARG"
 fi

--- a/i3-mode.el
+++ b/i3-mode.el
@@ -114,6 +114,17 @@ different frame or a different buffer than the one displayed before the switch."
                 (setq unread-command-events (listify-key-sequence "\C-g"))))
           (error (apply #'i3-msg i3-command))))))
 
+
+;;;###autoload
+(defun i3-process-key (fn &rest i3-command)
+  "Same as `i3-integrated-key', but invoke the function directly, instead of
+seeking it with keys, useful for isolated key-bindins between i3 and emacs."
+  (let ((buf (car (buffer-list (selected-frame)))))
+    (switch-to-buffer buf)
+    (condition-case _
+        (funcall fn)
+      (error (apply #'i3-msg i3-command)))))
+
 
 ;;; installation
 

--- a/readme.org
+++ b/readme.org
@@ -54,10 +54,13 @@ same function. ~i3-mode~ allows me to fix this by binding ~C-<hjkl>~ in both
 ~i3/sway~ and ~emacs~:
 
 #+begin_src bash
-bindsym Control+l exec --no-startup-id i3-call focus right C-l
-bindsym Control+h exec --no-startup-id i3-call focus left C-h
-bindsym Control+k exec --no-startup-id i3-call focus up C-k
-bindsym Control+j exec --no-startup-id i3-call focus down C-j
+  bindsym Control+l exec --no-startup-id i3-call focus right C-l
+  bindsym Control+h exec --no-startup-id i3-call focus left C-h
+  bindsym Control+k exec --no-startup-id i3-call focus up C-k
+  bindsym Control+j exec --no-startup-id i3-call focus down C-j
+
+  # or use direct call symbol
+  bindysm Mod4+a exec --no-startup-id i3-call focus left "#'windmove-left"
 #+end_src
 
 which instructs ~i3~ to use ~C+<hjkl>~ to move focus when the current


### PR DESCRIPTION
This pull request provides another direct way to move the focus of window, by passing the symbol directly, to address the issue that conflicts the keybindings. Tested on latest Emacs 30.